### PR TITLE
fix tclean divergence for field ar

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -34,11 +34,11 @@
     "tclean_cube_pars": {
       "spw24": {
         "imagename": "uid___A001_X15a0_X1a4.s38_0.Sgr_A_star_sci.spw24.cube.I.iter1.reclean",
-        "cyclefactor": 2
+        "cyclefactor": 3
       },
       "spw26": {
         "imagename": "uid___A001_X15a0_X1a4.s38_0.Sgr_A_star_sci.spw26.cube.I.iter1.reclean",
-        "cyclefactor": 2
+        "cyclefactor": 3
       }
     }
   },


### PR DESCRIPTION
This fixes the divergence on SPWs 24 and 26 in issue #19.  Increasing cyclefactor to 3 worked. Tested on 10 channels per spw that included some previously bad cleans and they came out ok. 