### PR TITLE
Fix ao spw35 parameters

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -53,7 +53,7 @@
         "smoothfactor": 1,
         "minbeamfrac": 0.3,
         "cutthreshold": 0.01,
-        "nchan": -1,
+        "nchan": 1916,
         "start": "",
         "width": ""
       }

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -52,7 +52,10 @@
         "negativethreshold": 10,
         "smoothfactor": 1,
         "minbeamfrac": 0.3,
-        "cutthreshold": 0.01
+        "cutthreshold": 0.01,
+        "nchan": -1,
+        "start": "",
+        "width": ""
       }
     }
   },

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -53,7 +53,7 @@
         "smoothfactor": 1,
         "minbeamfrac": 0.3,
         "cutthreshold": 0.01,
-        "nchan": 3834,
+        "nchan": -1,
         "start": "",
         "width": ""
       }

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -53,7 +53,7 @@
         "smoothfactor": 1,
         "minbeamfrac": 0.3,
         "cutthreshold": 0.01,
-        "nchan": 1916,
+        "nchan": 3834,
         "start": "",
         "width": ""
       }


### PR DESCRIPTION
spw35 ao was giving this error:
```

2022-10-03 14:39:00     SEVERE  tclean::::casa  Task tclean raised an exception of class RuntimeError with the following message: Error in running Major Cycle : Cannot open existing image : /blue/adamginsburg/adamginsburg/ACES/workdir/ao_spw35_cube_TM1_A001_X15a0_X190/uid___A001_X15a0_X190.s38_0.Sgr_A_star_sci.spw35.cube.I.iter1.reclean.model : There is a shape mismatch between existing images ([1024, 2592, 1, 3834]) and current parameters ([1024, 2592, 1, 1916]). If you are attempting to restart a run with a new image shape, please change imagename and supply the old model or mask as inputs (via the startmodel or mask parameters) so that they can be regridded to the new shape before continuing.
2022-10-03 14:39:00     SEVERE  tclean::::casa  Exception Reported: Error in tclean: Error in running Major Cycle : Cannot open existing image : /blue/adamginsburg/adamginsburg/ACES/workdir/ao_spw35_cube_TM1_A001_X15a0_X190/uid___A001_X15a0_X190.s38_0.Sgr_A_star_sci.spw35.cube.I.iter1.reclean.model : There is a shape mismatch between existing images ([1024, 2592, 1, 3834]) and current parameters ([1024, 2592, 1, 1916]). If you are attempting to restart a run with a new image shape, please change imagename and supply the old model or mask as inputs (via the startmodel or mask parameters) so that they can be regridded to the new shape before continuing.

```
which seems to arise because `nchan` was set by default (by the size mitigator) to 1916 channels.