### PR TITLE
Updated channel parameters to undo size mitigation for region ac (#232)

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2690,6 +2690,31 @@
   },
   "Sgr_A_st_ac_03_TM1": {
     "tclean_cube_pars": {
+      "spw25": {
+        "nchan": 1914,
+        "width": "0.24416125MHz",
+        "threshold": "0.0119Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "0.2441613MHz",
+        "threshold": "0.0069Jy"
+      },
+      "spw29": {
+        "nchan": 1914,
+        "width": "0.030526MHz",
+        "threshold": "0.0191Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "0.0305259MHz",
+        "threshold": "0.0127Jy"
+      },
+      "spw35": {
+        "nchan": 3834,
+        "width": "0.4883134MHz",
+        "threshold": "0.0041Jy"
+      },
       "spw33": {
         "nchan": 3836,
         "start": "97.6660537907GHz",


### PR DESCRIPTION
Updated channel widths, nchans, and cleaning thresholds for SPWs 25, 27, 29, 31 & 35 for Sgr_A_st_ac_03_TM1 (https://github.com/ACES-CMZ/reduction_ACES/issues/232).