### PR TITLE
Updated channel parameters to undo size mitigation for region ad (#28)

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -319,6 +319,31 @@
   },
   "Sgr_A_st_ad_03_TM1": {
     "tclean_cube_pars": {
+      "spw25": {
+        "nchan": 1914,
+        "width": "0.24412815MHz",
+        "threshold": "0.011Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "0.2441282MHz",
+        "threshold": "0.0065Jy"
+      },
+      "spw29": {
+        "nchan": 1914,
+        "width": "0.030519MHz",
+        "threshold": "0.0188Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "0.03051895MHz",
+        "threshold": "0.0126Jy"
+      },
+      "spw35": {
+        "nchan": 3834,
+        "width": "0.48825175MHz",
+        "threshold": "0.0056Jy"
+      },
       "spw33": {
         "nchan": 3836,
         "start": "97.6660537907GHz",


### PR DESCRIPTION
Updated channel widths, nchans, and cleaning thresholds for SPWs 25, 27, 29, 31 & 35 for Sgr_A_st_ad_03_TM1 (https://github.com/ACES-CMZ/reduction_ACES/issues/28).