### PR TITLE
Updating channel parameters for #41

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -735,6 +735,26 @@
   },
   "Sgr_A_st_ao_03_TM1": {
     "tclean_cube_pars": {
+      "spw25": {
+        "nchan": 1914,
+        "width": "0.2441183MHz",
+        "threshold": "0.0224Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "0.2441183MHz",
+        "threshold": "0.0079Jy"
+      },
+      "spw29": {
+        "nchan": 1914,
+        "width": "0.03051485MHz",
+        "threshold": "0.0228Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "0.03051485MHz",
+        "threshold": "0.0228Jy"
+      },
       "spw33": {
         "nchan": -1,
         "start": "",


### PR DESCRIPTION
Updated channel parameters and threshold for cubes for SPWs 25, 27, 29, and 31. 
This is for Sgr_A_st_ao_03_TM1 (#41), which is in addition to the changes made by Pei-Ying/Adam (#274) for SPWs 33 & 35.