### PR TITLE
Update tclean cube params for region v_TM1

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -3473,6 +3473,26 @@
   },
   "Sgr_A_st_v_03_TM1": {
     "tclean_cube_pars": {
+      "spw25": {
+        "nchan": 1914,
+        "width": "0.2441613MHz",
+        "threshold": "0.0076Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "0.24416135MHz",
+        "threshold": "0.0075Jy"
+      },
+      "spw29": {
+        "nchan": 1914,
+        "width": "0.03052565MHz",
+        "threshold": "0.0205Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "0.03052555MHz",
+        "threshold": "0.0136Jy"
+      },
       "spw33": {
         "nchan": -1,
         "start": "",


### PR DESCRIPTION
Updated channel parameters and thresholds for SPWs 25, 27, 29, 31 to undo size mitigation for Sgr_A_st_v_03_TM1 (#235). SPW 33 and 35 were already done. 