### PR TITLE
Update tclean cube params for region n_TM1

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -3522,6 +3522,31 @@
   },
   "Sgr_A_st_n_03_TM1": {
     "tclean_cube_pars": {
+      "spw25": {
+        "nchan": 1914,
+        "width": "0.24416045MHz",
+        "threshold": "0.0096Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "0.2441605MHz",
+        "threshold": "0.0070Jy"
+      },
+      "spw29": {
+        "nchan": 1914,
+        "width": "0.0305254MHz",
+        "threshold": "0.0191Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "0.0305253MHz",
+        "threshold": "0.0125Jy"
+      },
+      "spw35": {
+        "nchan": 3834,
+        "width": "0.4883126MHz",
+        "threshold": "0.0061Jy"
+      },
       "spw33": {
         "nchan": -1,
         "start": "",


### PR DESCRIPTION
Updated channel parameters and cleaning thresholds for SPWs 25, 27, 29, 31, and 35 to undo size mitigation for region Sgr_A_st_n_03_TM1 (https://github.com/ACES-CMZ/reduction_ACES/issues/231).