### PR TITLE
Create spectral_extraction_Nov2022.py

### DIFF
--- a/aces/analysis/spectral_extraction_Nov2022.py
+++ b/aces/analysis/spectral_extraction_Nov2022.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         product_dir = product_dict[regname]
         reg = regions_dict[regname]
 
-        cubefns = glob.glob(f'{product_dir}/product/*Sgr_A_star*.cube.I.pbcor.fits')
+        cubefns = glob.glob(f'{product_dir}/calibrated/working/*Sgr_A_star*.cube.I.pbcor.fits')
 
         for fn in cubefns:
             cube = SpectralCube.read(fn).subcube_from_regions([reg])

--- a/aces/analysis/spectral_extraction_Nov2022.py
+++ b/aces/analysis/spectral_extraction_Nov2022.py
@@ -1,0 +1,47 @@
+import regions
+from numpy import floor, ceil
+from astropy import coordinates
+from astropy import units as u
+import glob
+from spectral_cube import SpectralCube
+from spectral_cube import wcs_utils
+
+from .. import conf
+basepath = conf.basepath
+
+
+class getslice(object):
+    def __getitem__(self, x):
+        return x
+
+
+if __name__ == "__main__":
+
+    product_dict = {'SgrC_coreMM1': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001/X15a0/X172/",
+                    'SgrC_coreMM2': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001/X15a0/X172/"
+                    }
+
+    regions_dict = {'SgrC_coreMM1': regions.CircleSkyRegion(coordinates.SkyCoord('17:44:40.60', '-29:28:16.0', frame='icrs', unit=(u.h, u.deg)), radius=0.75 * u.arcsec),
+                    'SgrC_coreMM2': regions.CircleSkyRegion(coordinates.SkyCoord('17:44:40.21', '-29:28:12.5', frame='icrs', unit=(u.h, u.deg)), radius=0.75 * u.arcsec),
+                    }
+
+    for regname in product_dict:
+        print(regname)
+        product_dir = product_dict[regname]
+        reg = regions_dict[regname]
+
+        cubefns = glob.glob(f'{product_dir}/product/*Sgr_A_star*.cube.I.pbcor.fits')
+
+        for fn in cubefns:
+            cube = SpectralCube.read(fn).subcube_from_regions([reg])
+            print(cube)
+            avg = cube.mean(axis=(1, 2))
+            hdu = avg.hdu
+            y, x = cube.wcs.celestial.world_to_pixel(reg.center)
+
+            slc = getslice()[int(floor(x)):int(ceil(x)), int(floor(y)):int(ceil(y)), :]
+            ww = wcs_utils.slice_wcs(cube.wcs, slc, numpy_order=False)
+            hdu.header.update(ww.to_header())
+            hdu.data = hdu.data[:, None, None]
+
+            hdu.writeto(f"{regname}_average_" + fn.split("/")[-1], overwrite=True)

--- a/aces/analysis/spectral_extraction_Nov2022.py
+++ b/aces/analysis/spectral_extraction_Nov2022.py
@@ -17,8 +17,8 @@ class getslice(object):
 
 if __name__ == "__main__":
 
-    product_dict = {'SgrC_coreMM1': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001/X15a0/X172/",
-                    'SgrC_coreMM2': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001/X15a0/X172/"
+    product_dict = {'SgrC_coreMM1': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001_X15a0_X172/",
+                    'SgrC_coreMM2': f"{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/member.uid___A001_X15a0_X172/"
                     }
 
     regions_dict = {'SgrC_coreMM1': regions.CircleSkyRegion(coordinates.SkyCoord('17:44:40.60', '-29:28:16.0', frame='icrs', unit=(u.h, u.deg)), radius=0.75 * u.arcsec),


### PR DESCRIPTION
Script to extract spectra towards cores MM1 and MM2 in Sgr C. They should be in 36j in the mosaic and we will need 12m data -->  uid://A001/X15a0/X172. As a region I choose 0.75'' of radius to extract the spectra from about the 12m beam size. I have prepared a script based on that used in the past to extract other spectra. I am not sure about the path used since it starts from "rawdata". Adam could you please check if it is ok or if I should use an updated one with the reduced data (I see that pipelines have been run for this part of the 12 mosaic)?