### PR TITLE
Various script updates, incl. pipeline version change

### DIFF
--- a/aces/analysis/cube_stats_grid.py
+++ b/aces/analysis/cube_stats_grid.py
@@ -120,7 +120,7 @@ def main(num_workers=None):
 
     colnames_apriori = ['Field', 'Config', 'spw', 'suffix', 'filename', 'bmaj', 'bmin', 'bpa', 'wcs_restfreq', 'minfreq', 'maxfreq']
     colnames_fromheader = ['imsize', 'cell', 'threshold', 'niter', 'pblimit', 'pbmask', 'restfreq', 'nchan',
-                           'width', 'start', 'chanchunks', 'deconvolver', 'weighting', 'robust', 'git_version', 'git_date', ]
+                           'width', 'start', 'chanchunks', 'deconvolver', 'weighting', 'robust', 'git_version', 'git_date', 'version']
     colnames_stats = ('min max std sum mean'.split() +
                       'min_K max_K std_K sum_K mean_K'.split() +
                       'lowmin lowmax lowstd lowmadstd lowsum lowmean'.split() +
@@ -128,7 +128,7 @@ def main(num_workers=None):
 
     colnames = colnames_apriori + colnames_fromheader + colnames_stats
     # sanity check to make sure I didn't mis-count things above
-    assert len(colnames) == 49
+    assert len(colnames) == 50
 
     def try_qty(x):
         try:

--- a/aces/analysis/imstats.py
+++ b/aces/analysis/imstats.py
@@ -254,9 +254,9 @@ def imstats(fn, reg=None):
         cube = SpectralCube.read(fn, format='casa_image')
         data = cube[0].value
         ww = cube.wcs
-        
+
         # lots of work to get CASA version
-        metatb = Table.read(fn+"/logtable")
+        metatb = Table.read(f"{fn}/logtable")
         hist = metatb['MESSAGE']
         history = {x.split(":")[0]: ":".join(x.split(": ")[1:])
                    for x in hist if ':' in x and 'ICRS' not in x}

--- a/aces/analysis/imstats.py
+++ b/aces/analysis/imstats.py
@@ -257,9 +257,9 @@ def imstats(fn, reg=None):
         
         # lots of work to get CASA version
         metatb = Table.read(fn+"/logtable")
-        hist = logtable['MESSAGE']
+        hist = metatb['MESSAGE']
         history = {x.split(":")[0]: ":".join(x.split(": ")[1:])
-                    for x in hist if ':' in x and 'ICRS' not in x}
+                   for x in hist if ':' in x and 'ICRS' not in x}
         history.update({x.split("=")[0]: x.split("=")[1].lstrip()
                         for x in hist if '=' in x})
         casaversion = history['version']

--- a/aces/analysis/imstats.py
+++ b/aces/analysis/imstats.py
@@ -249,10 +249,20 @@ def imstats(fn, reg=None):
         fh = fits.open(fn)
         data = fh[0].data
         ww = wcs.WCS(fh[0].header)
+        casaversion = fh[0].header['ORIGIN']
     except IsADirectoryError:
         cube = SpectralCube.read(fn, format='casa_image')
         data = cube[0].value
         ww = cube.wcs
+        
+        # lots of work to get CASA version
+        metatb = Table.read(fn+"/logtable")
+        messages = metatb['MESSAGE']
+        history = {x.split(":")[0]: ":".join(x.split(": ")[1:])
+                    for x in hist if ':' in x and 'ICRS' not in x}
+        history.update({x.split("=")[0]: x.split("=")[1].lstrip()
+                        for x in hist if '=' in x})
+        casaversion = history['version']
 
     mad = mad_std(data, ignore_nan=True)
     peak = np.nanmax(data)

--- a/aces/analysis/imstats.py
+++ b/aces/analysis/imstats.py
@@ -257,7 +257,7 @@ def imstats(fn, reg=None):
         
         # lots of work to get CASA version
         metatb = Table.read(fn+"/logtable")
-        messages = metatb['MESSAGE']
+        hist = logtable['MESSAGE']
         history = {x.split(":")[0]: ":".join(x.split(": ")[1:])
                     for x in hist if ':' in x and 'ICRS' not in x}
         history.update({x.split("=")[0]: x.split("=")[1].lstrip()

--- a/aces/analysis/spectral_extraction_Feb2022.py
+++ b/aces/analysis/spectral_extraction_Feb2022.py
@@ -6,7 +6,7 @@ import glob
 from spectral_cube import SpectralCube
 from spectral_cube import wcs_utils
 
-from .. import conf
+from aces import conf
 basepath = conf.basepath
 
 

--- a/aces/analysis/spectral_extraction_Nov2022.py
+++ b/aces/analysis/spectral_extraction_Nov2022.py
@@ -6,7 +6,7 @@ import glob
 from spectral_cube import SpectralCube
 from spectral_cube import wcs_utils
 
-from .. import conf
+from aces import conf
 basepath = conf.basepath
 
 
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         product_dir = product_dict[regname]
         reg = regions_dict[regname]
 
-        cubefns = glob.glob(f'{product_dir}/calibrated/working/*Sgr_A_star*.cube.I.pbcor.fits')
+        cubefns = glob.glob(f'{product_dir}/calibrated/working/*Sgr_A_star*.cube.I.iter1.image.pbcor.fits')
 
         for fn in cubefns:
             cube = SpectralCube.read(fn).subcube_from_regions([reg])

--- a/aces/hipergator_scripts/ghapi_update.py
+++ b/aces/hipergator_scripts/ghapi_update.py
@@ -152,7 +152,7 @@ def main(dryrun=False):
         # New weblogs were discovered September 2, 2022.  Don't know what they are yet.
         extra_weblogs = [x.rstrip("/") for x in glob.glob(f'/orange/adamginsburg/web/secure/ACES/weblogs/humanreadable/{new_sb.strip().replace(" ", "_")}*/')
                          if os.path.basename(x.rstrip('/')) != new_sb.strip().replace(" ", "_")]
-        extra_weblog_urls = [f"{humanreadable_url}/{os.path.basename(xtra)}" for xtra in extra_weblogs]
+        extra_weblog_urls = [f"{humanreadable_url}/{os.path.basename(xtra)}/html/" for xtra in extra_weblogs]
         if any(extra_weblog_urls):
             extra_weblog_line = "\n   * " + ", ".join([f"[Extra Weblog {os.path.basename(xtra)} -> {os.path.basename(os.path.realpath(xtra))}]({url})"
                                                        for xtra, url in zip(extra_weblogs, extra_weblog_urls)])

--- a/aces/hipergator_scripts/ghapi_update.py
+++ b/aces/hipergator_scripts/ghapi_update.py
@@ -120,7 +120,8 @@ def main(dryrun=False):
             mses = (glob.glob(f'{calibrated_dir}/*.ms') +
                     glob.glob(f'{calibrated_dir}/*.ms.split.cal'))
         pipeline_run = os.path.exists(calibrated_dir) and len(mses) > 0
-        pipeline_links = [x.replace("/orange/adamginsburg/web/secure/", "https://data.rc.ufl.edu/secure/adamginsburg/")
+        pipeline_links = [x.replace("/orange/adamginsburg/web/secure/",
+                                    "https://data.rc.ufl.edu/secure/adamginsburg/")
                           for x in glob.glob(f"/orange/adamginsburg/web/secure/ACES/weblogs-reimaging/member.{mous}/pipeline*/html/t1-4.html")]
 
         product_dir = f'{basepath}/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.{gous}/member.{mous}/product'

--- a/aces/hipergator_scripts/run_cube_stats_grid.sh
+++ b/aces/hipergator_scripts/run_cube_stats_grid.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #SBATCH --mail-type=NONE          # Mail events (NONE, BEGIN, END, FAIL, ALL)
 #SBATCH --mail-user=adamginsburg@ufl.edu     # Where to send mail
-#SBATCH --ntasks=32
+#SBATCH --ntasks=64
 #SBATCH --nodes=1
-#SBATCH --mem=128gb                     # Job memory request
+#SBATCH --mem=256gb                     # Job memory request
 #SBATCH --time=96:00:00               # Time limit hrs:min:sec
 #SBATCH --output=cube_stats_grid_ACES_%j.log
 #SBATCH --export=ALL

--- a/aces/hipergator_scripts/run_imagingpipeline_inplace.sh
+++ b/aces/hipergator_scripts/run_imagingpipeline_inplace.sh
@@ -27,6 +27,8 @@ WORK_DIR='/orange/adamginsburg/ACES/rawdata/2021.1.00172.L'
 export ACES_ROOTDIR="/orange/adamginsburg/ACES/reduction_ACES/"
 
 CASAVERSION=casa-6.2.1-7-pipeline-2021.2.0.128
+# Changed 2022-11-30:
+CASAVERSION=casa-6.4.3-2-pipeline-2021.3.0.17
 export CASAPATH=/orange/adamginsburg/casa/${CASAVERSION}
 export MPICASA=${CASAPATH}/bin/mpicasa
 export CASA=${CASAPATH}/bin/casa

--- a/aces/hipergator_scripts/run_imstats.sh
+++ b/aces/hipergator_scripts/run_imstats.sh
@@ -12,6 +12,7 @@
 #SBATCH --account=adamginsburg
 pwd; hostname; date
 
+export WORK_DIR="/orange/adamginsburg/ACES/reduction_ACES/"
 export WORK_DIR="/blue/adamginsburg/adamginsburg/ACES/workdir"
 
 module load git
@@ -44,4 +45,6 @@ export DASK_THREADS=$SLURM_NTASKS
 
 env
 
-/orange/adamginsburg/miniconda3/envs/python39/bin/aces_cube_stats_grid
+/orange/adamginsburg/miniconda3/envs/python39/bin/aces_imstats
+#${IPYTHON} -c "from aces.analysis import
+#${IPYTHON} ${SCRIPT_DIR}/cube_stats_grid.py

--- a/aces/hipergator_scripts/run_imstats.sh
+++ b/aces/hipergator_scripts/run_imstats.sh
@@ -5,14 +5,13 @@
 #SBATCH --nodes=1
 #SBATCH --mem=128gb                     # Job memory request
 #SBATCH --time=96:00:00               # Time limit hrs:min:sec
-#SBATCH --output=cube_stats_grid_ACES_%j.log
+#SBATCH --output=imstats_ACES_%j.log
 #SBATCH --export=ALL
-#SBATCH --job-name=cube_stats_grid_ACES
+#SBATCH --job-name=imstats_ACES
 #SBATCH --qos=adamginsburg-b
 #SBATCH --account=adamginsburg
 pwd; hostname; date
 
-export WORK_DIR="/orange/adamginsburg/ACES/reduction_ACES/"
 export WORK_DIR="/blue/adamginsburg/adamginsburg/ACES/workdir"
 
 module load git
@@ -46,5 +45,3 @@ export DASK_THREADS=$SLURM_NTASKS
 env
 
 /orange/adamginsburg/miniconda3/envs/python39/bin/aces_imstats
-#${IPYTHON} -c "from aces.analysis import
-#${IPYTHON} ${SCRIPT_DIR}/cube_stats_grid.py

--- a/aces/imaging/write_tclean_scripts.py
+++ b/aces/imaging/write_tclean_scripts.py
@@ -89,7 +89,7 @@ def main():
                     config = sbname.split("_")[5]
                     print(f"{sbname} {mous} {partype} {spwsel} {field} {config}: ", end=" ")
                     if not all(os.path.exists(x) for x in tcpars['vis']) and os.getenv('TRYDROPTARGET'):
-                        tcpars['vis'] = [x.replace("_target", "") for x in tcpars["vis"]]
+                        tcpars['vis'] = [x.replace("_targets", "") for x in tcpars["vis"]]
 
                     # Nov 10, 2022: try removing "_lines" from files:
                     if all(os.path.exists(x.replace("_targets_line", "")) for x in tcpars['vis']):

--- a/aces/pipeline_scripts/generate_spw33_commands.py
+++ b/aces/pipeline_scripts/generate_spw33_commands.py
@@ -25,7 +25,8 @@ def main():
     with open(f"{pipedir}/override_tclean_commands.json", "r") as fh:
         override_commands = json.load(fh)
 
-    ncmds = (len(commands))
+    # check to make sure we only net increase # of commands
+    ncmds = (len(override_commands))
 
     #chwid = '488244Hz'
     #nchan = 3836
@@ -46,7 +47,7 @@ def main():
                     override_commands[key]['tclean_cube_pars']['spw33'] = spw33pars
                 else:
                     override_commands[key] = {'tclean_cube_pars': {'spw33': spw33pars}}
-            elif commands[key]['tclean_cube_pars']['spw33']['nchan'] < 3800:
+            elif ('nchan' not in commands[key]['tclean_cube_pars']['spw33']) or commands[key]['tclean_cube_pars']['spw33']['nchan'] < 3800:
                 print(f"Modifying {key}")
                 spw33pars = {}
                 spw33pars['nchan'] = -1
@@ -57,6 +58,9 @@ def main():
                     override_commands[key]['tclean_cube_pars']['spw33'] = spw33pars
                 else:
                     override_commands[key] = {'tclean_cube_pars': {'spw33': spw33pars}}
+            else:
+                # should be OK; already has spw33?
+                pass
 
     assert len(override_commands) >= ncmds
 

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2,9 +2,14 @@
   "Sgr_A_st_al_03_TM1": {
     "manual QA": "True",
     "mous": "uid://A001/X15a0/X142",
-    "pipeline_run": ["pipeline-20220530T124105", "pipeline-20220620T040157",
-        "pipeline-20220713T220117", "pipeline-20220720T040119",
-        "pipeline-20220805T145417", "pipeline-20220928T001318"],
+    "pipeline_run": [
+      "pipeline-20220530T124105",
+      "pipeline-20220620T040157",
+      "pipeline-20220713T220117",
+      "pipeline-20220720T040119",
+      "pipeline-20220805T145417",
+      "pipeline-20220928T001318"
+    ],
     "tclean_cont_pars": {
       "aggregate": {
         "vis": [
@@ -19,9 +24,9 @@
         ],
         "timerange": "",
         "uvrange": "",
-        "antenna":[
-            "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41&",
-            "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
+        "antenna": [
+          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41&",
+          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
         ],
         "imagename": "uid___A001_X15a0_X142.s36_0.Sgr_A_star_sci.spw25_27_29_31_33_35.cont.I.iter1",
         "imsize": [
@@ -443,99 +448,10 @@
         "parallel": true
       },
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8b429_Xa4c5_target.ms",
-          "uid___A002_Xf8f6a9_X216b_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X17e.s38_0.Sgr_A_star_sci.spw33.cube.I.manual.reclean",
-        "imsize": [
-          2304,
-          3750
-        ],
-        "cell": [
-          "0.28arcsec"
-        ],
-        "phasecenter": "ICRS 17:46:29.197  -028.32.13.868",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 1000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 2.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": false,
-        "savemodel": "none",
-        "calcres": true,
-        "calcpsf": true,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
       },
       "spw35": {
         "vis": [
@@ -645,117 +561,10 @@
   "Sgr_A_st_ap_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf89be2_Xcf2b_target.ms",
-          "uid___A002_Xf89be2_Xd5f3_target.ms",
-          "uid___A002_Xf89be2_Xdba9_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X196.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1.reclean",
-        "imsize": [
-          1458,
-          1440
-        ],
-        "cell": [
-          "0.3arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:06.8450 -029.15.25.480",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 4.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -858,117 +667,10 @@
   "Sgr_A_st_y_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf512ae_X64a7_target.ms",
-          "uid___A002_Xf531c1_X14f4_target.ms",
-          "uid___A002_Xf53eeb_X3071_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
-        ],
-        "scan": [
-          "7,10",
-          "7,10,13",
-          "7,10,13"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X130.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1250,
-          1600
-        ],
-        "cell": [
-          "0.27arcsec"
-        ],
-        "phasecenter": "ICRS 17:44:45.4764 -029.09.46.649",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.0101Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -1010,113 +712,10 @@
   "Sgr_A_st_j_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf53eeb_X184f5_target.ms",
-          "uid___A002_Xf53eeb_X18fd3_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_Xd6.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1620,
-          1600
-        ],
-        "cell": [
-          "0.27arcsec"
-        ],
-        "phasecenter": "ICRS 17:47:37.7505 -028.20.09.805",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.0,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -1126,8 +725,7 @@
         "nchan": -1,
         "start": "",
         "width": "",
-        "threshold": "0.012Jy",
-        "cyclefactor": 2.0
+        "threshold": "0.01Jy"
       },
       "spw25": {
         "nchan": 1912,
@@ -1159,569 +757,50 @@
   "Sgr_A_st_ai_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8d822_X728a_target.ms",
-          "uid___A002_Xf8f6a9_X85e2_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X16c.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1728,
-          1458
-        ],
-        "cell": [
-          "0.29arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:04.6879 -029.04.21.050",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_ae_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8f6a9_Xe40_target.ms",
-          "uid___A002_Xf8f6a9_X1947_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X154.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1458,
-          1440
-        ],
-        "cell": [
-          "0.3arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:06.5942 -029.20.58.285",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_l_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8f6a9_X1251d_target.ms",
-          "uid___A002_Xf8f6a9_X199a6_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_Xe2.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1728,
-          2500
-        ],
-        "cell": [
-          "0.26arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:31.5117 -029.22.35.507",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 90000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_z_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8f6a9_X269f_target.ms",
-          "uid___A002_Xf8f6a9_X9732_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X136.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1500,
-          1458
-        ],
-        "cell": [
-          "0.29arcsec"
-        ],
-        "phasecenter": "ICRS 17:46:47.4980 -028.25.31.044",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.0,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 9000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_q_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf84513_X23b6_target.ms",
-          "uid___A002_Xf859f0_X3e35_target.ms",
-          "uid___A002_Xf859f0_X43e5_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X100.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1458,
-          1440
-        ],
-        "cell": [
-          "0.3arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:06.6914 -029.09.51.931",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -1753,565 +832,50 @@
         "threshold": "0.00632Jy"
       },
       "spw33": {
-        "vis": [
-          "uid___A002_Xf934b1_X30dd_target.ms",
-          "uid___A002_Xf96bbc_X3e74_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_Xca.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          2250,
-          2160
-        ],
-        "cell": [
-          "0.21arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:33.6149 -029.09.47.682",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 2.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 5.0,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 7.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_an_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8f6a9_X2f1d_target.ms",
-          "uid___A002_Xf8f6a9_X8d0c_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X18a.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1458,
-          1440
-        ],
-        "cell": [
-          "0.3arcsec"
-        ],
-        "phasecenter": "ICRS 17:47:12.4370 -028.31.09.877",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_w_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8b429_X991b_target.ms",
-          "uid___A002_Xf8f6a9_X1b8a0_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X124.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1536,
-          1600
-        ],
-        "cell": [
-          "0.28arcsec"
-        ],
-        "phasecenter": "ICRS 17:48:02.7061 -028.25.35.219",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_m_03_TM1_updated": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf84513_X1134_target.ms",
-          "uid___A002_Xf84513_X2e72_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46&"
-        ],
-        "scan": [
-          "7,10,13,16,19",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15b4_X41.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1500,
-          1458
-        ],
-        "cell": [
-          "0.29arcsec"
-        ],
-        "phasecenter": "ICRS 17:47:12.7389 -028.20.06.177",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.0,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 2.5,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 3.0,
-        "noisethreshold": 5.0,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_j_03_TM1_updated": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf87688_Xc13_target.ms",
-          "uid___A002_Xf87688_Xf8e_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15b4_X3d.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1620,
-          1600
-        ],
-        "cell": [
-          "0.27arcsec"
-        ],
-        "phasecenter": "ICRS 17:47:37.7505 -028.20.09.805",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.0,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 4000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 2.5,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 3.0,
-        "noisethreshold": 5.0,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -2466,339 +1030,30 @@
   "Sgr_A_st_ab_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf8d822_X6bdc_target.ms",
-          "uid___A002_Xf8f6a9_X1ab3f_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&"
-        ],
-        "scan": [
-          "6,9,12,15",
-          "6,9,12,15"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X142.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1440,
-          1600
-        ],
-        "cell": [
-          "0.28arcsec"
-        ],
-        "phasecenter": "ICRS 17:45:29.7981 -029.15.19.041",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_t_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf84513_X1a3e_target.ms",
-          "uid___A002_Xf84513_Xd44b_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X112.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1440,
-          1440
-        ],
-        "cell": [
-          "0.31arcsec"
-        ],
-        "phasecenter": "ICRS 17:44:41.5755 -029.15.17.933",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 10000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
   "Sgr_A_st_ar_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf859f0_X4107_target.ms",
-          "uid___A002_Xf87688_X931_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X1a2.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1536,
-          1458
-        ],
-        "cell": [
-          "0.29arcsec"
-        ],
-        "phasecenter": "ICRS 17:46:47.4939 -028.31.03.627",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 4000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 2.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 3.0,
-        "noisethreshold": 5.0,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -2930,113 +1185,10 @@
   "Sgr_A_st_m_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf53eeb_Xa0e8_target.ms",
-          "uid___A002_Xf53eeb_X1055f_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
-        ],
-        "scan": [
-          "7,10,13,16,19",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_Xe8.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1500,
-          1458
-        ],
-        "cell": [
-          "0.29arcsec"
-        ],
-        "phasecenter": "ICRS 17:47:12.7389 -028.20.06.177",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 70000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -3050,117 +1202,10 @@
     },
     "tclean_cube_pars": {
       "spw33": {
-        "vis": [
-          "uid___A002_Xf89be2_Xe4fd_target.ms",
-          "uid___A002_Xf8b429_X1ea4_target.ms",
-          "uid___A002_Xf8b429_X2c01_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X172.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          1440,
-          1536
-        ],
-        "cell": [
-          "0.31arcsec"
-        ],
-        "phasecenter": "ICRS 17:44:41.3845 -029.26.46.873",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
         "nchan": -1,
         "start": "",
         "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.0,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 4.25,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 15.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
+        "threshold": "0.01Jy"
       }
     }
   },
@@ -3329,9 +1374,9 @@
       },
       "spw33": {
         "nchan": -1,
+        "start": "",
         "width": "",
-        "threshold": "0.01Jy",
-        "cyclefactor": 3
+        "threshold": "0.01Jy"
       },
       "spw35": {
         "nchan": -1,
@@ -3496,7 +1541,7 @@
       "spw33": {
         "nchan": -1,
         "start": "",
-        "width": "488310Hz",
+        "width": "",
         "threshold": "0.01Jy"
       },
       "spw35": {
@@ -3588,9 +1633,282 @@
   "Sgr_A_st_c_03_TM1": {
     "tclean_cube_pars": {
       "spw33": {
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
+      }
+    }
+  },
+  "Sgr_A_st_aa_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
+      }
+    }
+  },
+  "Sgr_A_st_k_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "nchan": 3832,
+        "width": "488309.6Hz",
+        "threshold": "0.014Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      },
+      "spw25": {
+        "nchan": 1912,
+        "width": "244154.8Hz",
+        "threshold": "0.028Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      },
+      "spw27": {
+        "nchan": 1912,
+        "width": "244154.8Hz",
+        "threshold": "0.017Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      },
+      "spw29": {
+        "nchan": 1908,
+        "width": "30519.4Hz",
+        "threshold": "0.03Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      },
+      "spw31": {
+        "nchan": 1912,
+        "width": "30519.4Hz",
+        "threshold": "0.03Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      },
+      "spw35": {
+        "nchan": 3832,
+        "width": "488309.6Hz",
+        "threshold": "0.014Jy",
+        "cell": "0.18arcsec",
+        "imsize": [
+          2400,
+          2400
+        ]
+      }
+    }
+  },
+  "Sgr_A_st_ah_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
+      },
+      "spw25": {
+        "nchan": 1912,
+        "width": "244155.25Hz",
+        "threshold": "0.022Jy"
+      },
+      "spw27": {
+        "nchan": 1914,
+        "width": "244155.25Hz",
+        "threshold": "0.013Jy"
+      },
+      "spw29": {
+        "nchan": 1912,
+        "width": "30519.45Hz",
+        "threshold": "0.035Jy"
+      },
+      "spw31": {
+        "nchan": 1914,
+        "width": "30519.45Hz",
+        "threshold": "0.024Jy"
+      },
+      "spw35": {
+        "nchan": 3832,
+        "width": "488310.45Hz",
+        "threshold": "0.015Jy"
+      }
+    }
+  },
+  "Sgr_A_st_a_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
+      }
+    }
+  },
+  "Sgr_A_st_r_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "threshold": "0.01Jy"
+      }
+    }
+  },
+  "Sgr_A_st_af_03_7M": {
+    "tclean_cube_pars": {
+      "spw24": {
+        "cyclefactor": 1.5
+      }
+    }
+  },
+  "Sgr_A_st_r_03_7M": {
+    "tclean_cube_pars": {
+      "spw24": {
+        "cyclefactor": 1.5
+      }
+    }
+  },
+  "Sgr_A_st_i_updated_03_7M": {
+    "tclean_cube_pars": {
+      "spw26": {
+        "cyclefactor": 1.5
+      }
+    }
+  },
+  "Sgr_A_st_s_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
         "vis": [
-          "uid___A002_Xfe90b7_X2ab_targets_line.ms",
-          "uid___A002_Xfe90b7_X7016_targets_line.ms"
+          "uid___A002_Xfed4ee_X1e3_targets_line.ms",
+          "uid___A002_Xfee03e_X2787_targets_line.ms"
+        ],
+        "selectdata": true,
+        "field": "Sgr_A_star",
+        "spw": [
+          "33",
+          "33"
+        ],
+        "timerange": "",
+        "uvrange": "",
+        "antenna": [
+          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&",
+          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&"
+        ],
+        "scan": [
+          "6,9,12,15,18",
+          "6,9,12,15,18"
+        ],
+        "observation": "",
+        "intent": "OBSERVE_TARGET#ON_SOURCE",
+        "datacolumn": "data",
+        "imagename": "uid___A001_X15a0_X10c.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
+        "imsize": [
+          1458,
+          1440
+        ],
+        "cell": [
+          "0.3arcsec"
+        ],
+        "phasecenter": "ICRS 17:46:22.3869 -028.47.36.061",
+        "stokes": "I",
+        "projection": "SIN",
+        "startmodel": "",
+        "specmode": "cube",
+        "reffreq": "",
+        "nchan": -1,
+        "start": "",
+        "width": "",
+        "outframe": "LSRK",
+        "veltype": "radio",
+        "restfreq": [],
+        "interpolation": "linear",
+        "perchanweightdensity": true,
+        "gridder": "mosaic",
+        "facets": 1,
+        "psfphasecenter": "",
+        "wprojplanes": 1,
+        "vptable": "",
+        "mosweight": true,
+        "aterm": true,
+        "psterm": false,
+        "wbawp": true,
+        "conjbeams": false,
+        "cfcache": "",
+        "usepointing": false,
+        "computepastep": 360.0,
+        "rotatepastep": 360.0,
+        "pointingoffsetsigdev": [],
+        "pblimit": 0.2,
+        "normtype": "flatnoise",
+        "deconvolver": "hogbom",
+        "scales": [],
+        "nterms": 2,
+        "smallscalebias": 0.0,
+        "restoration": true,
+        "restoringbeam": "common",
+        "pbcor": true,
+        "outlierfile": "",
+        "weighting": "briggsbwtaper",
+        "robust": 0.0,
+        "noise": "1.0Jy",
+        "npixels": 0,
+        "uvtaper": [
+          ""
+        ],
+        "niter": 20000000,
+        "gain": 0.1,
+        "threshold": "0.01Jy",
+        "nsigma": 0.0,
+        "cycleniter": -1,
+        "cyclefactor": 1.0,
+        "minpsffraction": 0.05,
+        "maxpsffraction": 0.8,
+        "interactive": 0,
+        "usemask": "auto-multithresh",
+        "mask": "",
+        "pbmask": 0.0,
+        "sidelobethreshold": 2.0,
+        "noisethreshold": 4.25,
+        "lownoisethreshold": 1.5,
+        "negativethreshold": 15.0,
+        "smoothfactor": 1.0,
+        "minbeamfrac": 0.3,
+        "cutthreshold": 0.01,
+        "growiterations": 50,
+        "dogrowprune": true,
+        "minpercentchange": 1.0,
+        "verbose": false,
+        "fastnoise": false,
+        "restart": true,
+        "savemodel": "none",
+        "calcres": false,
+        "calcpsf": false,
+        "psfcutoff": 0.35,
+        "parallel": true
+      }
+    }
+  },
+  "Sgr_A_st_e_03_TM1": {
+    "tclean_cube_pars": {
+      "spw33": {
+        "vis": [
+          "uid___A002_Xfe90b7_Xbd5d_targets_line.ms",
+          "uid___A002_Xfeb5e6_Xb30_targets_line.ms"
         ],
         "selectdata": true,
         "field": "Sgr_A_star",
@@ -3602,7 +1920,7 @@
         "uvrange": "",
         "antenna": [
           "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43&"
+          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42&"
         ],
         "scan": [
           "6,9,12,15,18",
@@ -3611,7 +1929,7 @@
         "observation": "",
         "intent": "OBSERVE_TARGET#ON_SOURCE",
         "datacolumn": "data",
-        "imagename": "uid___A001_X15a0_Xac.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
+        "imagename": "uid___A001_X15a0_Xb8.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
         "imsize": [
           1600,
           1536
@@ -3619,7 +1937,7 @@
         "cell": [
           "0.28arcsec"
         ],
-        "phasecenter": "ICRS 17:46:22.6098 -028.42.03.206",
+        "phasecenter": "ICRS 17:44:41.4044 -029.20.50.353",
         "stokes": "I",
         "projection": "SIN",
         "startmodel": "",
@@ -3695,241 +2013,6 @@
         "calcpsf": false,
         "psfcutoff": 0.35,
         "parallel": true
-      }
-    }
-  },
-  "Sgr_A_st_aa_03_TM1": {
-    "tclean_cube_pars": {
-      "spw33": {
-        "nchan": -1,
-        "start": "",
-        "width": "",
-        "threshold": "0.01Jy"
-      }
-    }
-  },
-  "Sgr_A_st_k_03_TM1": {
-    "tclean_cube_pars": {
-      "spw33": {
-        "nchan": 3832,
-        "width": "488309.6Hz",
-        "threshold": "0.014Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      },
-      "spw25": {
-        "nchan": 1912,
-        "width": "244154.8Hz",
-        "threshold": "0.028Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      },
-      "spw27": {
-        "nchan": 1912,
-        "width": "244154.8Hz",
-        "threshold": "0.017Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      },
-      "spw29": {
-        "nchan": 1908,
-        "width": "30519.4Hz",
-        "threshold": "0.03Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      },
-      "spw31": {
-        "nchan": 1912,
-        "width": "30519.4Hz",
-        "threshold": "0.03Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      },
-      "spw35": {
-        "nchan": 3832,
-        "width": "488309.6Hz",
-        "threshold": "0.014Jy",
-        "cell": "0.18arcsec",
-        "imsize": [2400,2400]
-      }
-    }
-  },
-  "Sgr_A_st_ah_03_TM1": {
-    "tclean_cube_pars": {
-      "spw33": {
-        "vis": [
-          "uid___A002_Xfddca6_Xe2c_target.ms",
-          "uid___A002_Xfddca6_X174f_target.ms"
-        ],
-        "selectdata": true,
-        "field": "Sgr_A_star",
-        "spw": [
-          "33",
-          "33"
-        ],
-        "timerange": "",
-        "uvrange": "",
-        "antenna": [
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&",
-          "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44&"
-        ],
-        "scan": [
-          "6,9,12,15,18",
-          "6,9,12,15,18"
-        ],
-        "observation": "",
-        "intent": "OBSERVE_TARGET#ON_SOURCE",
-        "datacolumn": "corrected",
-        "imagename": "uid___A001_X15a0_X166.s38_0.Sgr_A_star_sci.spw33.cube.I.iter1",
-        "imsize": [
-          2160,
-          2160
-        ],
-        "cell": [
-          "0.2arcsec"
-        ],
-        "phasecenter": "ICRS 17:48:26.7837 -028.19.57.073",
-        "stokes": "I",
-        "projection": "SIN",
-        "startmodel": "",
-        "specmode": "cube",
-        "reffreq": "",
-        "nchan": -1,
-        "start": "",
-        "width": "",
-        "outframe": "LSRK",
-        "veltype": "radio",
-        "restfreq": [],
-        "interpolation": "linear",
-        "perchanweightdensity": true,
-        "gridder": "mosaic",
-        "facets": 1,
-        "psfphasecenter": "",
-        "wprojplanes": 1,
-        "vptable": "",
-        "mosweight": true,
-        "aterm": true,
-        "psterm": false,
-        "wbawp": true,
-        "conjbeams": false,
-        "cfcache": "",
-        "usepointing": false,
-        "computepastep": 360.0,
-        "rotatepastep": 360.0,
-        "pointingoffsetsigdev": [],
-        "pblimit": 0.2,
-        "normtype": "flatnoise",
-        "deconvolver": "hogbom",
-        "scales": [],
-        "nterms": 2,
-        "smallscalebias": 0.0,
-        "restoration": true,
-        "restoringbeam": "common",
-        "pbcor": true,
-        "outlierfile": "",
-        "weighting": "briggsbwtaper",
-        "robust": 0.5,
-        "noise": "1.0Jy",
-        "npixels": 0,
-        "uvtaper": [
-          ""
-        ],
-        "niter": 20000000,
-        "gain": 0.1,
-        "threshold": "0.01Jy",
-        "nsigma": 0.0,
-        "cycleniter": -1,
-        "cyclefactor": 1.0,
-        "minpsffraction": 0.05,
-        "maxpsffraction": 0.8,
-        "interactive": 0,
-        "usemask": "auto-multithresh",
-        "mask": "",
-        "pbmask": 0.0,
-        "sidelobethreshold": 2.0,
-        "noisethreshold": 5.0,
-        "lownoisethreshold": 1.5,
-        "negativethreshold": 7.0,
-        "smoothfactor": 1.0,
-        "minbeamfrac": 0.3,
-        "cutthreshold": 0.01,
-        "growiterations": 50,
-        "dogrowprune": true,
-        "minpercentchange": 1.0,
-        "verbose": false,
-        "fastnoise": false,
-        "restart": true,
-        "savemodel": "none",
-        "calcres": false,
-        "calcpsf": false,
-        "psfcutoff": 0.35,
-        "parallel": true
-      },
-      "spw25": {
-        "nchan": 1912,
-        "width": "244155.25Hz",
-        "threshold": "0.022Jy"
-      },
-      "spw27": {
-        "nchan": 1914,
-        "width": "244155.25Hz",
-        "threshold": "0.013Jy"
-      },
-      "spw29": {
-        "nchan": 1912,
-        "width": "30519.45Hz",
-        "threshold": "0.035Jy"
-      },
-      "spw31": {
-        "nchan": 1914,
-        "width": "30519.45Hz",
-        "threshold": "0.024Jy"
-      },
-      "spw35": {
-        "nchan": 3832,
-        "width": "488310.45Hz",
-        "threshold": "0.015Jy"
-      }
-    }
-  },
-  "Sgr_A_st_a_03_TM1": {
-    "tclean_cube_pars": {
-      "spw33": {
-        "nchan": -1,
-        "start": "",
-        "width": "",
-        "threshold": "0.01Jy"
-      }
-    }
-  },
-  "Sgr_A_st_r_03_TM1": {
-    "tclean_cube_pars": {
-      "spw33": {
-        "nchan": -1,
-        "start": "",
-        "width": "",
-        "threshold": "0.01Jy"
-      }
-    }
-  },
-  "Sgr_A_st_af_03_7M": {
-    "tclean_cube_pars": {
-      "spw24": {
-        "cyclefactor": 1.5
-      }
-    }
-  },
-  "Sgr_A_st_r_03_7M": {
-    "tclean_cube_pars": {
-      "spw24": {
-        "cyclefactor": 1.5
-      }
-    }
-  },
-  "Sgr_A_st_i_updated_03_7M": {
-    "tclean_cube_pars": {
-      "spw26": {
-        "cyclefactor": 1.5
       }
     }
   }

--- a/aces/retrieval_scripts/retrieve_weblogs.py
+++ b/aces/retrieval_scripts/retrieve_weblogs.py
@@ -27,7 +27,7 @@ def main(username=None):
     alma.archive_url = 'https://almascience.eso.org'
     alma.dataarchive_url = 'https://almascience.eso.org'
 
-    alma.login(username)
+    alma.login(username, auth_urls=['almascience.nrao.edu', 'almascience.eso.org', 'asa.alma.cl', 'rh-cas.alma.cl'])
     print(f"Logged in as {username}.  Performing weblog query.", flush=True)
 
     results = alma.query(payload=dict(project_code='2021.1.00172.L'), public=None)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ setenv =
     MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
The pipeline version used for ALMA-pipeline-based reimaging, which was not used for everything but may be used for 7m data, was using CASA 6.2 instead of 6.4.  This updates to use 6.4 instead.

The overall reimaging is using `casa-6.4.4-31-py3.8` rather than `casa-6.4.3-2-pipeline-2021.3.0.17`.  I'm not sure when I made that decision, but I should have documented it better.  Using a non-pipeline version of CASA is slightly preferable because it has faster startup, but that means there is an inconsistency in the versions used for imaging.

Other fixes in this PR are small but critical typo fixes.  Notably, the weblog links should go straight to the weblog instead of the folder containing the html/ folder from now on.