### PR TITLE
Minor update to increase cyclefactor and use default channel parameters

### DIFF
--- a/aces/joint_deconvolution/clean_HNCO_12m_7m.py
+++ b/aces/joint_deconvolution/clean_HNCO_12m_7m.py
@@ -67,6 +67,4 @@ for i in range(len(sb_names)):
         hnco_pars['width']       = ''
         hnco_pars['nchan']       = -1
         hnco_pars['start']       = ''
-
-
         tclean(**hnco_pars)

--- a/aces/joint_deconvolution/clean_HNCO_12m_7m.py
+++ b/aces/joint_deconvolution/clean_HNCO_12m_7m.py
@@ -61,11 +61,12 @@ for i in range(len(sb_names)):
         hnco_pars['imagename']   = workdir + '/' + sb_names['Region'][i] + '/' + sb_names['Region'][i] + '_12m_7m.HNCO.clean'
         hnco_pars['calcpsf']     = True
         hnco_pars['calcres']     = True
-        hnco_pars['cyclefactor'] = 1.5
+        hnco_pars['cyclefactor'] = 2.5
         hnco_pars['antenna']     = ''
         hnco_pars['scan']        = ''
-        if hnco_pars['nchan'] < 1000:
-            hnco_pars['nchan']   = hnco_pars['nchan'] * 2
-            hnco_pars['width']   = str(float(re.sub('MHz', '', hnco_pars['width'])) / 2.0) + 'MHz'
+        hnco_pars['width']       = ''
+        hnco_pars['nchan']       = -1
+        hnco_pars['start']       = ''
+
 
         tclean(**hnco_pars)


### PR DESCRIPTION
Increased cyclefactor from 1.5 -> 2.5. I found that using 1.5 resulted in divergence very often. 2.5 seems to fix this for the majority of cases, at the expense of efficiency. 

Since I was grabbing the default 12m parameters, the channel parameters were often for the size-mitigated products. I was previously using a clunky if statement to scale the parameters appropriately, but in a few cases this failed because CASA complained about the channel width being ever-so-slightly different than what it expected. I've now just set them all to blank/default instead.