### PR TITLE
reclean parameters for Sgr_A_st_e_updated_03_7M

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -3833,10 +3833,18 @@
       }
     }
   },
-    "Sgr_A_st_y_03_7M": {
+  "Sgr_A_st_y_03_7M": {
     "tclean_cube_pars": {
       "spw24": {
         "cyclefactor": 2.0
+      }
+    }
+  },
+  "Sgr_A_st_e_updated_03_7M": {
+    "tclean_cube_pars": {
+      "spw24": {
+        "imagename": "uid___A001_X15b4_X39.s38_0.Sgr_A_star_sci.spw24.cube.I.iter1.reclean",
+        "cyclefactor": 3.0
       }
     }
   }


### PR DESCRIPTION
Reclean parameters for Sgr_A_st_e_updated_03_7M (#168 )
However, the reclean has been run on local machines and the image cubes have been uploaded to globus, so it is not necessary to trigger the reclean.