### PR TITLE
reclean parameters for Sgr_A_st_p_03_7M

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -3847,5 +3847,14 @@
         "cyclefactor": 3.0
       }
     }
+  },
+  "Sgr_A_st_p_03_7M": {
+    "tclean_cube_pars": {
+      "spw24": {
+        "imagename": "uid___A001_X15a0_Xfc.s38_0.Sgr_A_star_sci.spw24.cube.I.iter1.reclean",
+        "cyclefactor": 4.0,
+        "threshold": "0.32Jy"
+      }
+    }
   }
 }


### PR DESCRIPTION
Reclean parameters for Sgr_A_st_p_03_7M (#148 )
However, the reclean has been run on local machines and the image cubes have been uploaded to globus, so it is not necessary to trigger the reclean.