### PR TITLE
Update tox.ini to ignore errors of TP-ACA-feather.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,3 +108,4 @@ per-file-ignores =
     aces/imaging/make_mosaic_12m.py:E226,F841
     aces/imaging/parallel_tclean.py:E303,F541,E122
     aces/hipergator_scripts/job_runner.py:W503
+    aces/imaging/TP-ACA-feather.py:W504,E265,F401,W292


### PR DESCRIPTION
I added a line in tox.ini
aces/imaging/TP-ACA-feather.py:W504,E265,F401,W292