### PR TITLE
Add globus cli script

### DIFF
--- a/aces/retrieval_scripts/globus_cli_template.sh
+++ b/aces/retrieval_scripts/globus_cli_template.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This is an example template for using the Globus CLI to transfer data from HPG to a local machine
+# This example is for transferring the 12m HNCO fits files, and uses the aces_SB_uids.csv file to get the list of SB uids
+# This is designed to work with a direcotry structure that directly mirrors the HPG directory structure
+
+# Define endpoint IDs and target paths
+hpg=insert_hpg_endpoint_id_here
+hpg_pth=/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/
+local=insert_local_endpoint_id_here
+local_pth=~/rawdata/2021.1.00172.L/science_goal.uid___A001_X1590_X30a8/group.uid___A001_X1590_X30a9/
+
+csv_file='./../data/tables/aces_SB_uids.csv'
+column_number=2
+
+rm aces_12m_HNCO_fits.txt
+awk -F ',' -v col=$column_number '{
+    if (NR > 1) {  # Skip the header row
+        print $col  # Print the value of the specified column
+    }
+}' "$csv_file" | while read -r uid; do
+    # Define the source path
+    src_path=$hpg_pth"member.uid___A001_"$uid"/"
+    # Define the destination path
+    dst_path=$local_pth"member.uid___A001_"$uid"/"
+    mkdir -p "$dst_path"
+    mkdir -p $dst_path"product/"
+    # Write the paths of the files to be transferred to a text file
+    globus ls $hpg:\~$src_path"product/" --filter '~*spw31.cube.I.pbcor.fits*' | xargs -i echo $src_path"product/{}" >> aces_12m_HNCO_fits.txt
+done
+
+# Transfer the files
+while IFS= read -r fn;
+do
+  if [ ! -f "~/$fn" ]; then
+    globus transfer "$hpg:~$fn" "$local:~/$fn"
+  fi
+done < aces_12m_HNCO_fits.txt

--- a/aces/retrieval_scripts/globus_cli_template.sh
+++ b/aces/retrieval_scripts/globus_cli_template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is an example template for using the Globus CLI to transfer data from HPG to a local machine
 # This example is for transferring the 12m HNCO fits files, and uses the aces_SB_uids.csv file to get the list of SB uids
-# This is designed to work with a direcotry structure that directly mirrors the HPG directory structure
+# This is designed to work with a directory structure that directly mirrors the HPG directory structure
 
 # Define endpoint IDs and target paths
 hpg=insert_hpg_endpoint_id_here


### PR DESCRIPTION
This is an example template for using the [Globus CLI](https://docs.globus.org/cli/) to transfer data from HPG to a local machine. This specific example was used for transferring the 12m HNCO fits files, and uses [aces_SB_uids.csv](https://github.com/ACES-CMZ/reduction_ACES/blob/b0e74276fd5340ae7ae0a8d85e153e8ea4ba6561/aces/data/tables/aces_SB_uids.csv) to get the list of SB uids. This is designed to work with a directory structure that directly mirrors the HPG directory structure.

To use this, you'll need to update your endpoint IDs and paths accordingly, and obviously update the query parameters to suit your needs.

If anyone has any suggested updates/improvements, that'd be great. This method is a bit awkward, and relies on using `ls` to query globus, writing the output to a text file, and then using this file to initiate the transfer requests. For some reason, the globus `transfer` function only allows the use of wildcards to exclude files, not include them, hence the `ls` workaround.