### PR TITLE
Updating tclean parameter for region ao 7M

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -3961,5 +3961,12 @@
         "cyclefactor": 3.0
       }
     }
+  },
+  "Sgr_A_st_x_03_7M": {
+    "tclean_cube_pars": {
+      "spw24": {
+        "cyclefactor": 2.0
+      }
+    }
   }
 }


### PR DESCRIPTION
Updating tclean parameter for Sgr_A_st_ao_03_7M, spw24: cyclefactor from 1.0 to 2.0 (issue #6) But please note that I have run the reimaging on a local machine and have uploaded the images to Globus. This commit is just for bookkeeping, there is no need to rerun the pipeline on hipergator.