### PR TITLE
Update override_tclean_commands.json for spw 22 & 26 of Sgr_A_st_i_up…

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2207,8 +2207,11 @@
   },
   "Sgr_A_st_i_updated_03_7M": {
     "tclean_cube_pars": {
+      "spw22": {
+        "cyclefactor": 3.5
+      },
       "spw26": {
-        "cyclefactor": 1.5
+        "cyclefactor": 3.0
       }
     }
   },


### PR DESCRIPTION
updated tclean parameters for SPWs 22 & 26 of Sgr_A_st_i_updated_03_7M (#191 )
NOTE that this PR is just for bookkeeping. I have rerun tclean on a local machine and uploaded new cubes to globus, so the re-imaging pipeline does not need to be triggered.