### PR TITLE
Updated tclean parameters for re-imaging TM1 region o, SPW 35

### DIFF
--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2318,7 +2318,7 @@
     }
   },
   "Sgr_A_st_aa_03_TM1": {
-    "clean_cube_pars": {
+    "tclean_cube_pars": {
       "spw25": {
         "nchan": 1912,
         "width": "0.2441565MHz"

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2307,11 +2307,18 @@
         "width": "",
         "threshold": "0.0153Jy",
         "cyclefactor": 3.0
+      },
+      "spw35": {
+        "nchan": -1,
+        "width": "0.4883123MHz",
+	"threshold": "0.0123Jy",
+	"cyclefactor": 3.0,
+	"weighting": "briggs"
       }
     }
   },
   "Sgr_A_st_aa_03_TM1": {
-    "tclean_cube_pars": {
+    "clean_cube_pars": {
       "spw25": {
         "nchan": 1912,
         "width": "0.2441565MHz"

--- a/aces/pipeline_scripts/override_tclean_commands.json
+++ b/aces/pipeline_scripts/override_tclean_commands.json
@@ -2310,7 +2310,7 @@
       },
       "spw35": {
         "nchan": -1,
-        "width": "0.4883123MHz",
+        "width": "",
 	"threshold": "0.0123Jy",
 	"cyclefactor": 3.0,
 	"weighting": "briggs"


### PR DESCRIPTION
Updated the override_tclean_parameters .json file to include the tclean parameters used to resolve divergence in SPW 35 of TM1 region o. 