### PR TITLE
remove skipping of icrs files

### DIFF
--- a/aces/data_deliverables/update_headers.py
+++ b/aces/data_deliverables/update_headers.py
@@ -280,7 +280,6 @@ def apply_fixes(fits_path: Path) -> tuple[bool, list[str]]:
 def main():
     fits_list = sorted([
         f for f in BASE_DIR.glob("*/*.fits")
-        if ".icrs" not in f.name # Skip the reprojected files (they should inherit header info from Galactic files, right???)
     ])
     total = len(fits_list)
 


### PR DESCRIPTION
Removed the line to skip any files with '.icrs' in the file name. 

This was previously put in place as we were planning to let the reprojected files inherent the updated header info from the Galactic files. Since we made the reprojected files before updating the headers, we will need to include them in the fix.