### PR TITLE
Make giant-mosaic weight mask channel-independent (fix per-channel NaN flicker)

### DIFF
--- a/aces/imaging/make_mosaic.py
+++ b/aces/imaging/make_mosaic.py
@@ -840,9 +840,19 @@ def make_giant_mosaic_cube(filelist,
         if len(weightcubes) == len(cubes) and min_weight_fraction is not None:
             # mask out the low-weight regions
             print(f"Masking out regions with weight < {min_weight_fraction} * max(weight)", flush=True)
-            # assume the middle of the cube is safe to save time
-            weightcubes = [weightcube.with_mask(weightcube > min_weight_fraction * weightcube[weightcube.shape[0] // 2, :, :].max())
-                           for weightcube in weightcubes]
+            # Build the footprint from the mid-channel plane and broadcast it across
+            # all channels, so the mask is CHANNEL-INDEPENDENT.  Masking each channel
+            # by its own weight makes a field's footprint edge drift with the mosaic-
+            # vs-native spectral-grid beat (mosaic cdelt != native cdelt), which
+            # flickers edge pixels in/out of the mask on a ~grid-beat period (seen as
+            # NaN blocks at single-coverage field margins, e.g. field ao in CH3CHO_3m13).
+            # A single 2D footprint per field removes that channel dependence.
+            new_weightcubes = []
+            for weightcube in weightcubes:
+                midplane = weightcube[weightcube.shape[0] // 2, :, :]
+                footprint = np.asarray(midplane > min_weight_fraction * midplane.max())
+                new_weightcubes.append(weightcube.with_mask(footprint[None, :, :]))
+            weightcubes = new_weightcubes
 
     # BUGFIX: there are FITS headers that incorrectly specify UTC in caps
     for cube in cubes + weightcubes:


### PR DESCRIPTION
## Problem

The giant-mosaic weight mask (`make_mosaic.make_giant_mosaic_cube`) thresholded **each weight-cube channel by its own values** (`weight > min_weight_fraction * max`). For fields whose native channel width differs from the mosaic grid (mosaic `cdelt` != native `cdelt`), the sampled weight channel drifts across the cube, so footprint-edge pixels near the threshold cross in/out of the mask on a grid-beat period.

Symptom found in the SPW35 `CH3CHO_3m13` cube: ~0.65% of pixels — concentrated at field **ao**'s footprint edge — flickered between finite and NaN with a **~56-channel period** (native 1.4444 km/s vs mosaic 1.47015 km/s). At a single-coverage edge pixel this reads as a NaN *block* on one side of the beat, e.g. voxel `(4799,2497,199)=NaN` but `(4799,2497,222)=finite`.

Cubes built with 45 solid weight cubes and no grid mismatch (HC3N, NSplus, CS21) show 0.00 flicker, which isolated the mechanism.

## Fix

Build a single 2D footprint from the mid-channel weight plane and broadcast it across all channels, so a field's mask is **channel-independent**. Flat/broadcast weights are unaffected (already constant); real spectrally-varying weight cubes on a mismatched grid no longer flicker.

Verified on field ao: mask is now identical across channels. flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
