### PR TITLE
Full-band 5"/10" downsampled per-spw cubes via the zarr combiner

### DIFF
--- a/aces/hipergator_scripts/slurm_fullband_downsampled.sh
+++ b/aces/hipergator_scripts/slurm_fullband_downsampled.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Full-band, 5" pixel, 10" beam per-spw overview cubes via the zarr combiner.
+# One array task per spw (25, 27, 33, 35).
+#
+# Runs in the python312-zarr env (editable worktrees of reproject@zarr,
+# spectral-cube, reduction_ACES) so the reproject return_type='zarr' feature is
+# available and the production env is untouched.  See README_zarr_combine.md.
+#
+# Usage:
+#   sbatch aces/hipergator_scripts/slurm_fullband_downsampled.sh
+# (or a single spw:  SPW=27 sbatch --array=0 ... )
+
+#SBATCH --job-name=aces_fullband_ds
+#SBATCH --output=/blue/adamginsburg/adamginsburg/ACES/logs/aces_fullband_ds_%A_%a.log
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=16
+#SBATCH --nodes=1
+#SBATCH --mem=256gb
+#SBATCH --time=48:00:00
+#SBATCH --array=0-3
+
+SPWS=(25 27 33 35)
+export SPW=${SPW:-${SPWS[$SLURM_ARRAY_TASK_ID]}}
+export PARALLEL=${PARALLEL:-16}
+
+PY=/blue/adamginsburg/adamginsburg/miniconda3/envs/python312-zarr/bin/python
+echo "SPW=$SPW PARALLEL=$PARALLEL"
+$PY -c "import reproject, spectral_cube; print('reproject', reproject.__version__)"
+$PY -m aces.imaging.run_fullband_downsampled

--- a/aces/hipergator_scripts/slurm_zarr_combine.sh
+++ b/aces/hipergator_scripts/slurm_zarr_combine.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Experimental single-pass giant-cube combiner (reproject return_type='zarr').
+#
+# Runs in the dedicated python312-zarr env (editable worktrees of
+# reproject@coadd-zarr-return, spectral-cube@zarr-combine, reduction_ACES@
+# giantcube-zarr-combiner) so the production python312 env / running jobs are
+# untouched.
+#
+# Usage:
+#   MOLNAME=CH3CHO_3m13 sbatch aces/hipergator_scripts/slurm_zarr_combine.sh
+# Optional env: PARALLEL, ZARR_BATCH_SIZE, BLOCK_SPATIAL, ZARR_PATH, OUTPUT_FILE, OVERWRITE
+#
+# ntasks should match PARALLEL (reproject uses that many threads).
+
+#SBATCH --job-name=aces_zarr_combine
+#SBATCH --output=/blue/adamginsburg/adamginsburg/ACES/logs/aces_zarr_combine_%j.log
+#SBATCH --account=astronomy-dept
+#SBATCH --qos=astronomy-dept-b
+#SBATCH --ntasks=16
+#SBATCH --nodes=1
+#SBATCH --mem=256gb
+#SBATCH --time=96:00:00
+
+export MOLNAME=${MOLNAME:?set MOLNAME (e.g. CH3CHO_3m13)}
+export PARALLEL=${PARALLEL:-16}
+
+PY=/blue/adamginsburg/adamginsburg/miniconda3/envs/python312-zarr/bin/python
+echo "MOLNAME=$MOLNAME PARALLEL=$PARALLEL"
+$PY -c "import reproject, spectral_cube, aces; print('reproject', reproject.__version__); print('spectral_cube', spectral_cube.__version__)"
+$PY -m aces.imaging.run_zarr_combine

--- a/aces/imaging/README_zarr_combine.md
+++ b/aces/imaging/README_zarr_combine.md
@@ -1,0 +1,46 @@
+# Experimental zarr giant-cube combiner
+
+Single-pass alternative to the channel-by-channel `make_giant_mosaic_cube`.
+Hands the full list of field cubes to one
+`reproject.mosaicking.reproject_and_coadd(return_type='zarr')` call, which
+computes the 3D mosaic block-by-block into a zarr store (bounded memory, truly
+parallel I/O) and returns dask arrays that are then streamed to FITS. Based on
+astrofrog's recipe (gist `81729066204b0332735b9461d015ee7c`) and
+astropy/reproject#621.
+
+## Isolation
+
+Everything runs in a dedicated conda env and editable worktrees so the
+production `python312` env and its running jobs are never disturbed:
+
+| component      | worktree                                                      | branch                     |
+|----------------|---------------------------------------------------------------|----------------------------|
+| reproject      | `/blue/adamginsburg/adamginsburg/repos/reproject-zarr`        | `coadd-zarr-return-wt`     |
+| spectral-cube  | `/blue/adamginsburg/adamginsburg/repos/spectral-cube-zarr`    | `zarr-combine`             |
+| reduction_ACES | `/blue/adamginsburg/adamginsburg/repos/reduction_ACES-zarr`   | `giantcube-zarr-combiner`  |
+| conda env      | `python312-zarr` (clone of `python312`, editables repointed)  |                            |
+
+## Run
+
+```bash
+MOLNAME=CH3CHO_3m13 sbatch aces/hipergator_scripts/slurm_zarr_combine.sh
+```
+
+`MOLCONFIG` in `run_zarr_combine.py` carries per-molecule params (spw, restfreq,
+cdelt, nchan, beam threshold) copied from the `make_giant_mosaic_cube_*`
+builders. Add a molecule by adding a row.
+
+Key settings (overridable via env): `PARALLEL=16`, `block_size=(1, 2048, -1)`,
+`zarr_batch_size=64`.
+
+## Open items to tune during the first real test
+
+- **Beam matching**: the channel path convolves each field to a common beam
+  before coadd; this combiner does *not* yet (the 3D convolve is expensive).
+  Decide whether per-field beam differences matter for the target line.
+- **Array extraction**: cubes are passed as `(cube.unitless_filled_data[:],
+  cube.wcs)`; weights as `nan_to_num(wc.unitless_filled_data[:])`. Confirm the
+  dask arrays stay lazy end-to-end (no accidental `.compute()`).
+- **block_size last dim** should match the output width for best efficiency
+  (`-1` = full width); raise `zarr_batch_size` on many cores.
+- `zarr_path` must not pre-exist (reproject enforces); `OVERWRITE=True` removes it.

--- a/aces/imaging/fullband_downsampled_cube.py
+++ b/aces/imaging/fullband_downsampled_cube.py
@@ -1,0 +1,170 @@
+"""
+Full-band, spatially-downsampled per-spw cubes via the zarr reproject_and_coadd
+combiner (the "new approach").
+
+For each spectral window (25, 27, 33, 35) this builds ONE cube covering the
+*entire* spw bandwidth (all native channels), reprojected onto a coarse **5
+arcsec** pixel grid and smoothed to a **10 arcsec** common beam.  These are
+low-resolution full-band overview cubes -- cheap to make and to browse -- as
+opposed to the per-line giant cubes.
+
+Why the zarr 3D combiner rather than the per-channel `make_giant_mosaic_cube`:
+the single `reproject.mosaicking.reproject_and_coadd(return_type='zarr')` call
+does one coherent 3D reprojection, so it avoids the per-channel two_closest /
+weight-slab machinery (and its data-vs-weight grid-offset NaN-striping bug).
+
+Weights: the per-field weight cubes are essentially constant along frequency, so
+we take each field's mid-channel weight plane, reproject it onto that field's
+celestial grid, and broadcast it across the field's channels.  This gives a
+correctly-located per-field weight without a full 3D weight reprojection and
+without the shape-mismatch hazard of the per-channel path.
+
+Resolution handling: fields are coadded at 5 arcsec sampling keeping their
+native (~2.5 arcsec) beams, then the assembled 5 arcsec mosaic is convolved to
+the 10 arcsec target beam (cheap at coarse sampling; 10 arcsec dominates the
+per-field beam spread).  This avoids an expensive native-resolution convolution.
+
+NB: uses the reproject `return_type='zarr'` feature (astropy/reproject#621) and
+must be run in an environment where that reproject and a compatible
+spectral-cube are installed (see aces/imaging/README_zarr_combine.md).  Set up
+here but not yet run end-to-end -- treat as review-ready scaffolding.
+"""
+import glob
+import os
+import shutil
+
+import numpy as np
+import radio_beam
+from astropy import units as u
+from astropy import wcs
+from astropy.io import fits
+
+from reproject import reproject_interp
+from reproject.mosaicking import reproject_and_coadd
+from spectral_cube import SpectralCube
+
+from aces.imaging.mosaic_12m import get_weightfile
+from aces import conf
+
+basepath = conf.basepath
+
+FEATHER = f'{basepath}/upload/Feather_12m_7m_TP'
+NATIVE_HEADER = f'{basepath}/reduction_ACES/aces/imaging/data/header_12m.hdr'
+
+# All ACES science spws we build full-band overview cubes for.
+SPWS = (25, 27, 33, 35)
+
+
+def spw_filelist(spw):
+    return sorted(glob.glob(f'{FEATHER}/SPW{spw}/cubes/'
+                            f'Sgr_A_st_*.TP_7M_12M_feather_all.SPW_{spw}.image.statcont.contsub.fits'))
+
+
+def build_target_header(spw, ref_cube_file, pixscale=5 * u.arcsec,
+                        native_header=NATIVE_HEADER):
+    """3D target header: the native celestial footprint downsampled to
+    ``pixscale`` pixels, plus the spw's native frequency axis taken from
+    ``ref_cube_file``."""
+    nat = fits.Header.fromtextfile(native_header)
+    native_pix = abs(nat['CDELT2']) * u.deg
+    factor = float((pixscale.to(u.deg) / native_pix).decompose())
+
+    hdr = nat.copy()
+    hdr['NAXIS'] = 3
+    hdr['WCSAXES'] = 3
+    # coarsen the two celestial axes by ``factor`` about the reference pixel
+    for ax in (1, 2):
+        n = nat[f'NAXIS{ax}']
+        hdr[f'NAXIS{ax}'] = int(np.ceil(n / factor))
+        hdr[f'CDELT{ax}'] = nat[f'CDELT{ax}'] * factor
+        hdr[f'CRPIX{ax}'] = (nat[f'CRPIX{ax}'] - 0.5) / factor + 0.5
+
+    # spectral axis: copy the spw's native FREQ grid
+    refh = fits.getheader(ref_cube_file)
+    refw = wcs.WCS(refh).spectral
+    n3 = refh['NAXIS3']
+    f0 = refw.pixel_to_world(0).to(u.Hz).value
+    f1 = refw.pixel_to_world(n3 - 1).to(u.Hz).value
+    hdr['NAXIS3'] = n3
+    hdr['CTYPE3'] = 'FREQ'
+    hdr['CUNIT3'] = 'Hz'
+    hdr['CRPIX3'] = 1
+    hdr['CRVAL3'] = f0
+    hdr['CDELT3'] = (f1 - f0) / (n3 - 1)
+    hdr['SPECSYS'] = 'LSRK'
+    return hdr
+
+
+def _weight_plane_on_grid(weightfile, refcube):
+    """Reproject a field's mid-channel weight plane onto ``refcube``'s celestial
+    grid and return it as a 2D array (weights are ~constant along frequency, so a
+    single plane suffices; it is broadcast across channels by the caller)."""
+    if weightfile.endswith('.fits'):
+        whdu = fits.open(weightfile)[0]
+        wdata = np.squeeze(whdu.data)
+        if wdata.ndim == 3:
+            wdata = wdata[wdata.shape[0] // 2]
+        wwcs = wcs.WCS(whdu.header).celestial
+    else:
+        wc = SpectralCube.read(weightfile, format='casa_image', use_dask=True)
+        wdata = np.squeeze(np.asarray(wc[wc.shape[0] // 2] if wc.ndim == 3 else wc))
+        wwcs = wc.wcs.celestial
+    plane, _ = reproject_interp((np.nan_to_num(wdata), wwcs),
+                                refcube.wcs.celestial, shape_out=refcube.shape[1:])
+    return np.nan_to_num(plane)
+
+
+def make_fullband_downsampled_cube(spw, output_file=None, zarr_path=None,
+                                   pixscale=5 * u.arcsec, target_beam=10 * u.arcsec,
+                                   parallel=16, block_size=(1, 2048, -1),
+                                   zarr_batch_size=64, overwrite=False, verbose=True):
+    """Build the full-band, ``pixscale``-pixel, ``target_beam``-beam cube for one spw."""
+    filelist = spw_filelist(spw)
+    if not filelist:
+        raise FileNotFoundError(f"No SPW{spw} feather cubes found")
+    weightfilelist = [get_weightfile(fn, spw=spw) for fn in filelist]
+
+    if output_file is None:
+        output_file = f'{basepath}/mosaics/cubes/SPW{spw}_fullband_5as_10as_CubeMosaic.fits'
+    if zarr_path is None:
+        zarr_path = f'/blue/adamginsburg/adamginsburg/ACES/workdir/mosaics/SPW{spw}_fullband.zarr'
+    if os.path.exists(zarr_path):
+        if overwrite:
+            shutil.rmtree(zarr_path)
+        else:
+            raise ValueError(f"zarr_path {zarr_path} exists (pass overwrite=True)")
+
+    header = build_target_header(spw, filelist[0], pixscale=pixscale)
+    target_wcs = wcs.WCS(header)
+    shape_out = (header['NAXIS3'], header['NAXIS2'], header['NAXIS1'])
+
+    if verbose:
+        print(f"SPW{spw}: {len(filelist)} fields -> {shape_out} at {pixscale} pixels", flush=True)
+
+    input_data, input_weights = [], []
+    for fn, wfn in zip(filelist, weightfilelist):
+        cube = SpectralCube.read(fn, use_dask=True)
+        plane = _weight_plane_on_grid(wfn, cube)
+        input_data.append((cube.unitless_filled_data[:], cube.wcs))
+        input_weights.append(np.broadcast_to(plane[None, :, :], cube.shape))
+
+    array, footprint = reproject_and_coadd(
+        input_data, target_wcs, shape_out=shape_out, input_weights=input_weights,
+        reproject_function=reproject_interp, combine_function='mean',
+        roundtrip_coords=False, parallel=parallel, block_size=block_size,
+        return_type='zarr', zarr_path=zarr_path, zarr_batch_size=zarr_batch_size)
+
+    # write the coadd (native-beam, 5") then convolve to the target beam
+    if verbose:
+        print(f"SPW{spw}: writing coadd -> {output_file}", flush=True)
+    fits.PrimaryHDU(data=np.asarray(array), header=header).writeto(output_file, overwrite=overwrite)
+
+    if verbose:
+        print(f"SPW{spw}: convolving to {target_beam} beam", flush=True)
+    sc = SpectralCube.read(output_file, use_dask=True)
+    beam = radio_beam.Beam(target_beam, target_beam, 0 * u.deg)
+    sc = sc.convolve_to(beam)
+    sc.write(output_file.replace('.fits', f'_{int(target_beam.value)}as.fits'), overwrite=overwrite)
+    if verbose:
+        print(f"SPW{spw}: done", flush=True)
+    return output_file

--- a/aces/imaging/mosaic_cube_zarr.py
+++ b/aces/imaging/mosaic_cube_zarr.py
@@ -1,0 +1,194 @@
+"""
+Experimental single-pass giant-cube combiner using reproject's zarr return mode.
+
+This is an alternative to the channel-by-channel `make_giant_mosaic_cube` path
+in `make_mosaic.py`.  Instead of mosaicking 350 channels independently and then
+stitching, it hands the full list of field cubes to a single
+`reproject.mosaicking.reproject_and_coadd` call with ``return_type='zarr'``,
+which computes the 3D mosaic block-by-block into a zarr store (bounded memory,
+truly parallel I/O) and returns dask arrays reading from that store.  The store
+is then streamed to FITS.
+
+Requires:
+  * reproject with the ``return_type='zarr'`` feature (astropy/reproject#621,
+    branch ``coadd-zarr-return``; merged into main 2026-07-06).
+  * These run in the dedicated ``python312-zarr`` conda env with editable
+    worktrees of reproject / spectral-cube / reduction_ACES, so the production
+    ``python312`` env (used by running jobs) is untouched.
+
+Settings recommended by astrofrog (gist 81729066204b0332735b9461d015ee7c),
+tuned for the ACES 12m giant cubes:
+
+    parallel=16, block_size=(1, 2048, -1),
+    return_type='zarr', zarr_path=..., zarr_batch_size=64
+
+The cube/weight/beam loading mirrors `make_mosaic.make_giant_mosaic_cube`
+(including the channel-independent flat/`min_weight_fraction` handling) so any
+molecule that has a `make_giant_mosaic_cube_*` builder can be routed here by
+passing the same filelist / reference_frequency / cdelt_kms / nchan.
+"""
+import os
+import warnings
+
+import numpy as np
+from astropy import units as u
+from astropy import wcs
+from astropy.io import fits
+
+from reproject import reproject_interp
+from reproject.mosaicking import reproject_and_coadd
+from spectral_cube import SpectralCube
+
+from aces.imaging.make_mosaic import (make_giant_mosaic_cube_header,
+                                      get_common_beam,
+                                      _weight_is_flat,
+                                      _flat_weightcube)
+from aces import conf
+
+basepath = conf.basepath
+
+
+def _load_cubes_and_weights(filelist, weightfilelist, reference_frequency,
+                            beam_threshold, min_weight_fraction=0.05,
+                            use_beams=True, verbose=True):
+    """Load data + weight cubes exactly as make_giant_mosaic_cube does: spectral
+    unit -> km/s at reference_frequency, drop cubes with beams above threshold,
+    broadcast flat weights, and apply a CHANNEL-INDEPENDENT min_weight_fraction
+    footprint mask.  Returns (cubes, weightcubes)."""
+    reference_frequency = u.Quantity(reference_frequency, u.Hz)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        cubes = [SpectralCube.read(fn,
+                                   format='fits' if fn.endswith('fits') else 'casa_image',
+                                   use_dask=True).with_spectral_unit(
+                                       u.km / u.s, velocity_convention='radio',
+                                       rest_value=reference_frequency)
+                 for fn in filelist]
+
+        weightcubes = []
+        for fn, refcube in zip(weightfilelist, cubes):
+            if _weight_is_flat(fn):
+                weightcubes.append(_flat_weightcube(fn, refcube))
+            else:
+                weightcubes.append(
+                    SpectralCube.read(fn, format='fits' if fn.endswith('fits') else 'casa_image',
+                                      use_dask=True).with_spectral_unit(
+                                          u.km / u.s, velocity_convention='radio',
+                                          rest_value=reference_frequency))
+
+        if min_weight_fraction is not None:
+            # channel-independent footprint from the mid plane (see the matching
+            # fix in make_mosaic.make_giant_mosaic_cube)
+            masked = []
+            for weightcube in weightcubes:
+                midplane = weightcube[weightcube.shape[0] // 2, :, :]
+                footprint = np.asarray(midplane > min_weight_fraction * midplane.max())
+                masked.append(weightcube.with_mask(footprint[None, :, :]))
+            weightcubes = masked
+
+    # normalise timesys casing (some FITS write UTC in caps)
+    for cube in cubes + weightcubes:
+        cube._wcs.wcs.timesys = cube.wcs.wcs.timesys.lower()
+        if hasattr(cube.mask, '_wcs'):
+            cube.mask._wcs.wcs.timesys = cube.wcs.wcs.timesys.lower()
+
+    # beam filter
+    if use_beams:
+        beams = [get_common_beam(cube.beams) if hasattr(cube, 'beams') else cube.beam
+                 for cube in cubes]
+        ok = [beam.major < beam_threshold for beam in beams]
+        if verbose and not all(ok):
+            dropped = [fn for fn, k in zip(filelist, ok) if not k]
+            print(f"Beam filter dropped {len(dropped)} cubes > {beam_threshold}: {dropped}", flush=True)
+        cubes = [c for k, c in zip(ok, cubes) if k]
+        weightcubes = [c for k, c in zip(ok, weightcubes) if k]
+
+    return cubes, weightcubes
+
+
+def giant_mosaic_cube_zarr(filelist,
+                           weightfilelist,
+                           reference_frequency,
+                           cdelt_kms,
+                           cubename,
+                           nchan,
+                           output_file=None,
+                           zarr_path=None,
+                           target_header=f'{basepath}/reduction_ACES/aces/imaging/data/header_12m.hdr',
+                           beam_threshold=2.75 * u.arcsec,
+                           min_weight_fraction=0.05,
+                           parallel=16,
+                           block_size=(1, 2048, -1),
+                           zarr_batch_size=64,
+                           combine_function='mean',
+                           use_beams=True,
+                           overwrite=False,
+                           verbose=True):
+    """
+    Build a giant mosaic cube in one reproject_and_coadd(return_type='zarr') call.
+
+    Parameters mirror make_giant_mosaic_cube where they overlap.  ``zarr_path``
+    must NOT already exist (reproject enforces this).  Writes the coadded array
+    to ``output_file`` (FITS) by streaming from the zarr store.
+    """
+    if output_file is None:
+        output_file = f'{basepath}/mosaics/cubes/{cubename}_CubeMosaic.fits'
+    if zarr_path is None:
+        zarr_path = f'/blue/adamginsburg/adamginsburg/ACES/workdir/mosaics/{cubename}_CubeMosaic.zarr'
+
+    if os.path.exists(zarr_path):
+        if overwrite:
+            import shutil
+            print(f"Removing existing zarr store {zarr_path}", flush=True)
+            shutil.rmtree(zarr_path)
+        else:
+            raise ValueError(f"zarr_path {zarr_path} already exists (pass overwrite=True to replace)")
+
+    header = make_giant_mosaic_cube_header(target_header=target_header,
+                                           reference_frequency=u.Quantity(reference_frequency, u.Hz),
+                                           cdelt_kms=cdelt_kms,
+                                           nchan=nchan)
+    target_wcs = wcs.WCS(header)
+    shape_out = (header['NAXIS3'], header['NAXIS2'], header['NAXIS1'])
+
+    if verbose:
+        print(f"Loading {len(filelist)} cubes + weights for {cubename}", flush=True)
+    cubes, weightcubes = _load_cubes_and_weights(
+        filelist, weightfilelist, reference_frequency,
+        beam_threshold=beam_threshold, min_weight_fraction=min_weight_fraction,
+        use_beams=use_beams, verbose=verbose)
+
+    if verbose:
+        print(f"Coadding {len(cubes)} cubes into {shape_out} via return_type='zarr' "
+              f"(parallel={parallel}, block_size={block_size}, batch={zarr_batch_size})", flush=True)
+
+    # input_data: (array, wcs) tuples on each field's own 3D grid; reproject_interp
+    # interpolates all three axes, so per-field spectral-grid differences are
+    # handled here (no pre-regridding needed).
+    input_data = [(cube.unitless_filled_data[:], cube.wcs) for cube in cubes]
+    # input_weights: finite arrays, 0 outside the footprint mask
+    input_weights = [np.nan_to_num(wc.unitless_filled_data[:]) for wc in weightcubes]
+
+    array, footprint = reproject_and_coadd(
+        input_data,
+        target_wcs,
+        shape_out=shape_out,
+        input_weights=input_weights,
+        reproject_function=reproject_interp,
+        combine_function=combine_function,
+        roundtrip_coords=False,
+        parallel=parallel,
+        block_size=block_size,
+        return_type='zarr',
+        zarr_path=zarr_path,
+        zarr_batch_size=zarr_batch_size,
+    )
+
+    if verbose:
+        print(f"Streaming coadded array {array.shape} -> {output_file}", flush=True)
+    header['BUNIT'] = 'Jy/beam'
+    fits.PrimaryHDU(data=array, header=header).writeto(output_file, overwrite=overwrite)
+    if verbose:
+        print(f"Wrote {output_file}", flush=True)
+    return output_file

--- a/aces/imaging/run_fullband_downsampled.py
+++ b/aces/imaging/run_fullband_downsampled.py
@@ -1,0 +1,32 @@
+"""Driver for the full-band spatially-downsampled per-spw cubes.
+
+Pick a spw with the SPW env var (25/27/33/35); optional overrides:
+PIXSCALE_AS, BEAM_AS, PARALLEL, ZARR_BATCH_SIZE, BLOCK_SPATIAL, OVERWRITE.
+
+    SPW=27 python -m aces.imaging.run_fullband_downsampled
+"""
+import os
+
+from astropy import units as u
+
+from aces.imaging.fullband_downsampled_cube import make_fullband_downsampled_cube, SPWS
+
+
+def main():
+    spw = int(os.environ['SPW'])
+    if spw not in SPWS:
+        raise ValueError(f"SPW={spw} not in {SPWS}")
+    kwargs = dict(
+        pixscale=float(os.environ.get('PIXSCALE_AS', 5)) * u.arcsec,
+        target_beam=float(os.environ.get('BEAM_AS', 10)) * u.arcsec,
+        parallel=int(os.environ.get('PARALLEL', 16)),
+        block_size=(1, int(os.environ.get('BLOCK_SPATIAL', 2048)), -1),
+        zarr_batch_size=int(os.environ.get('ZARR_BATCH_SIZE', 64)),
+        overwrite=os.environ.get('OVERWRITE', 'False') == 'True',
+    )
+    print(f"[fullband] SPW{spw} pixscale={kwargs['pixscale']} beam={kwargs['target_beam']}", flush=True)
+    make_fullband_downsampled_cube(spw, **kwargs)
+
+
+if __name__ == '__main__':
+    main()

--- a/aces/imaging/run_zarr_combine.py
+++ b/aces/imaging/run_zarr_combine.py
@@ -1,0 +1,78 @@
+"""
+Driver for the experimental zarr giant-cube combiner (mosaic_cube_zarr).
+
+Pick a cube with the MOLNAME env var; parameters (input glob, rest frequency,
+channel width, nchan, spw, beam threshold) come from MOLCONFIG below, which
+mirrors the corresponding make_giant_mosaic_cube_* builders in mosaic_12m.py.
+
+    MOLNAME=CH3CHO_3m13 python -m aces.imaging.run_zarr_combine
+
+Env overrides (all optional):
+    ZARR_PATH, OUTPUT_FILE, PARALLEL, ZARR_BATCH_SIZE, BLOCK_SPATIAL (the middle
+    block dim; block is (1, BLOCK_SPATIAL, -1)), OVERWRITE=True
+"""
+import glob
+import os
+
+from astropy import units as u
+
+from aces.imaging.mosaic_12m import get_weightfile
+from aces.imaging.mosaic_cube_zarr import giant_mosaic_cube_zarr
+
+FEATHER = '/orange/adamginsburg/ACES/upload/Feather_12m_7m_TP'
+
+
+def _spw_glob(spw):
+    return sorted(glob.glob(f'{FEATHER}/SPW{spw}/cubes/'
+                            f'Sgr_A_st_*.TP_7M_12M_feather_all.SPW_{spw}.image.statcont.contsub.fits'))
+
+
+# molname -> dict(spw, restfrq_Hz, cdelt_kms, nchan, beam_threshold_arcsec)
+# values copied from the make_giant_mosaic_cube_* builders in mosaic_12m.py
+MOLCONFIG = {
+    'CH3CHO_3m13': dict(spw=35, restfrq=101.343448e9, cdelt_kms=1.47015502, nchan=350, beam_threshold=2.75),
+    'HC3N': dict(spw=35, restfrq=100.0763e9, cdelt_kms=1.47015502, nchan=350, beam_threshold=2.75),
+    'NSplus': dict(spw=35, restfrq=100.198e9, cdelt_kms=1.47015502, nchan=350, beam_threshold=2.75),
+    'CH3OH_72-63': dict(spw=27, restfrq=86.902947e9, cdelt_kms=0.84455895, nchan=600, beam_threshold=3.3),
+    'CS21': dict(spw=33, restfrq=97.98095330e9, cdelt_kms=1.4844932, nchan=350, beam_threshold=2.9),
+}
+
+
+def main():
+    molname = os.environ['MOLNAME']
+    if molname not in MOLCONFIG:
+        raise KeyError(f"{molname} not in MOLCONFIG; add it (keys: {list(MOLCONFIG)})")
+    cfg = MOLCONFIG[molname]
+
+    filelist = _spw_glob(cfg['spw'])
+    if len(filelist) == 0:
+        raise FileNotFoundError(f"No SPW{cfg['spw']} feather cubes found for {molname}")
+    weightfilelist = [get_weightfile(fn, spw=cfg['spw']) for fn in filelist]
+    for wf in weightfilelist:
+        assert os.path.exists(wf), f"missing weight {wf}"
+
+    block_spatial = int(os.environ.get('BLOCK_SPATIAL', 2048))
+    kwargs = dict(
+        parallel=int(os.environ.get('PARALLEL', 16)),
+        block_size=(1, block_spatial, -1),
+        zarr_batch_size=int(os.environ.get('ZARR_BATCH_SIZE', 64)),
+        beam_threshold=cfg['beam_threshold'] * u.arcsec,
+        overwrite=os.environ.get('OVERWRITE', 'False') == 'True',
+    )
+    if os.environ.get('ZARR_PATH'):
+        kwargs['zarr_path'] = os.environ['ZARR_PATH']
+    if os.environ.get('OUTPUT_FILE'):
+        kwargs['output_file'] = os.environ['OUTPUT_FILE']
+
+    print(f"[zarr-combine] {molname}: {len(filelist)} cubes, spw{cfg['spw']}, "
+          f"restfrq={cfg['restfrq']/1e9:.4f} GHz, nchan={cfg['nchan']}", flush=True)
+    giant_mosaic_cube_zarr(filelist, weightfilelist,
+                           reference_frequency=cfg['restfrq'],
+                           cdelt_kms=cfg['cdelt_kms'],
+                           cubename=molname,
+                           nchan=cfg['nchan'],
+                           **kwargs)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Full-band spatially-downsampled per-spw cubes (via the zarr combiner)

Sets up (does **not** run) a pipeline to build **full-band** overview cubes for **spw 25, 27, 33, 35** — every native channel of each spw — reprojected to a coarse **5″ pixel** grid and smoothed to a **10″ beam**.

Built on the **"new approach"**: `reproject.mosaicking.reproject_and_coadd(return_type='zarr')` (astropy/reproject#621) — one coherent 3D reprojection into a zarr store (bounded memory, parallel I/O), streamed to FITS. This sidesteps the per-channel `two_closest`/weight-slab machinery of `make_giant_mosaic_cube` (and its data-vs-weight grid-offset NaN-striping bug).

### What's here
- `aces/imaging/fullband_downsampled_cube.py` — `make_fullband_downsampled_cube(spw, ...)`: 5″ target header (native footprint ÷10) + spw native FREQ axis; coadd fields at 5″ keeping native beams, then convolve the assembled mosaic to 10″.
- `aces/imaging/run_fullband_downsampled.py` — `SPW`-driven driver.
- `aces/hipergator_scripts/slurm_fullband_downsampled.sh` — array launcher (one task per spw).
- Also bundles the underlying zarr combiner (`mosaic_cube_zarr.py`, `run_zarr_combine.py`, `slurm_zarr_combine.sh`, `README_zarr_combine.md`).

### Design notes
- **Weights:** per-field weight cubes are ~constant along frequency, so we take the mid-channel weight plane, reproject it onto that field's celestial grid, and broadcast across channels — a correctly-located per-field weight without a 3D weight reproject and without the shape-mismatch hazard.
- **Resolution:** coadd at 5″ (native ~2.5″ beams), then convolve the small 5″ mosaic to 10″ — avoids an expensive native-resolution convolution; 10″ dominates the per-field beam spread.
- **Grid:** native 0.5″ / 11120×4080 → 5″ / **1112×408**; spectral kept native (SPW25/27 ≈1912 ch, SPW33/35 ≈3840 ch). Verified the SPW27 target header: 1112×408×1912, 5.0″ pixels, FREQ @ 86.6551 GHz.

### Status
Review-ready **scaffolding**; not yet run end-to-end. Runs in the `python312-zarr` env (zarr-enabled reproject + spectral-cube worktrees); the zarr combiner still needs memory-bounding validation on a real cube before a production run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
